### PR TITLE
Store certificate expiration in CADB

### DIFF
--- a/cadb/queries.go
+++ b/cadb/queries.go
@@ -63,9 +63,9 @@ func (conn *Conn) tryGetSerial() (*big.Int, error) {
 }
 
 // AddCert adds a newly generated certificate to the database.
-func (conn *Conn) AddCert(id string, serial *big.Int, cert []byte) error {
+func (conn *Conn) AddCert(id string, serial *big.Int, expiry time.Time, cert []byte) error {
 	// TODO: Inside of transaction.
-	_, err := conn.db.Exec(`INSERT INTO certs (id, serial, cert) VALUES (?, ?, ?)`,
-		id, serial.Int64(), cert)
+	_, err := conn.db.Exec(`INSERT INTO certs (id, serial, expiry, cert) VALUES (?, ?, ?, ?)`,
+		id, serial.Int64(), expiry, cert)
 	return err
 }

--- a/cadb/schema.go
+++ b/cadb/schema.go
@@ -20,10 +20,11 @@ var schema = []string{
 	`CREATE TABLE certs (id STRING NOT NULL REFERENCES devices(id),
 		serial STRING NOT NULL,
 		cert BLOB NOT NULL,
+		expiry DATE NOT NULL,
 		PRIMARY KEY (id, serial))`,
 }
 
-const schemaVersion = "20200820b"
+const schemaVersion = "20201020a"
 
 func (conn *Conn) checkSchema() error {
 	// Query the settings table for the schema version.

--- a/httpserver/csr.go
+++ b/httpserver/csr.go
@@ -28,11 +28,12 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 
 	ser, err := db.GetSerial()
 
+	expiry := time.Now().AddDate(1, 0, 0)
 	cert := &x509.Certificate{
 		SerialNumber: ser,
 		Subject:      csr.Subject,
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(1, 0, 0),
+		NotAfter:     expiry,
 		// TODO: Extensions that make sense to us.
 	}
 
@@ -46,7 +47,7 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 	}
 
 	id := cert.Subject.CommonName
-	err = db.AddCert(id, ser, signedCert)
+	err = db.AddCert(id, ser, expiry, signedCert)
 	if err != nil {
 		fmt.Printf("Add cert err: %v\n", err)
 		return nil, err


### PR DESCRIPTION
Store the expiration date as a field in the SQLite CADB instead of just
within the certificate.  This will make it easy to query for
certificates that are nearing expiry.

Fixes #1.

Signed-off-by: David Brown <david.brown@linaro.org>