### PR TITLE
Fix IsCA in certificate generation

### DIFF
--- a/cadb/queries.go
+++ b/cadb/queries.go
@@ -63,9 +63,9 @@ func (conn *Conn) tryGetSerial() (*big.Int, error) {
 }
 
 // AddCert adds a newly generated certificate to the database.
-func (conn *Conn) AddCert(id string, serial *big.Int, expiry time.Time, cert []byte) error {
+func (conn *Conn) AddCert(id string, serial *big.Int, keyId []byte, expiry time.Time, cert []byte) error {
 	// TODO: Inside of transaction.
-	_, err := conn.db.Exec(`INSERT INTO certs (id, serial, expiry, cert) VALUES (?, ?, ?, ?)`,
-		id, serial.Int64(), expiry, cert)
+	_, err := conn.db.Exec(`INSERT INTO certs (id, serial, keyid, expiry, cert) VALUES (?, ?, ?, ?, ?)`,
+		id, serial.Int64(), keyId, expiry, cert)
 	return err
 }

--- a/cadb/schema.go
+++ b/cadb/schema.go
@@ -19,12 +19,13 @@ var schema = []string{
 	// certs holds all of the certificates we've ever issued.
 	`CREATE TABLE certs (id STRING NOT NULL REFERENCES devices(id),
 		serial STRING NOT NULL,
+		keyid BLOB NOT NULL,
 		cert BLOB NOT NULL,
 		expiry DATE NOT NULL,
 		PRIMARY KEY (id, serial))`,
 }
 
-const schemaVersion = "20201020a"
+const schemaVersion = "20201027a"
 
 func (conn *Conn) checkSchema() error {
 	// Query the settings table for the schema version.

--- a/httpserver/csr.go
+++ b/httpserver/csr.go
@@ -40,14 +40,14 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 	// fmt.Printf("CSR: %v\n", csr)
 	// fmt.Printf("Cert: %v\n", cert)
 
-	signedCert, err := signCert(cert)
+	signedCert, err := signCert(cert, csr.PublicKey)
 	if err != nil {
 		fmt.Printf("Sign error: %v\n", err)
 		return nil, err
 	}
 
 	id := cert.Subject.CommonName
-	err = db.AddCert(id, ser, expiry, signedCert)
+	err = db.AddCert(id, ser, cert.SubjectKeyId, expiry, signedCert)
 	if err != nil {
 		fmt.Printf("Add cert err: %v\n", err)
 		return nil, err
@@ -56,7 +56,7 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 	return signedCert, nil
 }
 
-func signCert(template *x509.Certificate) ([]byte, error) {
+func signCert(template *x509.Certificate, pub interface{}) ([]byte, error) {
 	// TODO: Don't use hardcoded names here.
 	// TODO: This can probably share a bit of code with the root
 	// cert generation.
@@ -66,7 +66,7 @@ func signCert(template *x509.Certificate) ([]byte, error) {
 		return nil, err
 	}
 
-	cert, err := sig.SignTemplate(template)
+	cert, err := sig.SignTemplate(template, pub)
 	if err != nil {
 		return nil, err
 	}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -38,11 +38,12 @@ func NewSigningCert() (*SigningCert, error) {
 			Organization: []string{"Linaro, LTD"},
 			CommonName:   "LinaroCA Root Cert - 2020",
 		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(1, 0, 0),
-		IsCA:        true,
-		ExtKeyUsage: []x509.ExtKeyUsage{},
-		KeyUsage:    x509.KeyUsageCertSign,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{},
+		KeyUsage:              x509.KeyUsageCertSign,
 	}
 
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -50,6 +51,14 @@ func NewSigningCert() (*SigningCert, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Determine the KeyID based on the sha1 of the marshalled
+	// public key.
+	pubBytes := elliptic.Marshal(privKey.Curve, privKey.X, privKey.Y)
+	keyId := sha1.Sum(pubBytes)
+
+	ca.SubjectKeyId = keyId[:]
+	ca.AuthorityKeyId = keyId[:]
 
 	// Self sign this key.
 	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, &privKey.PublicKey, privKey)


### PR DESCRIPTION
The template was setting the IsCA to true, but without
BasicConstraintsValid also being set to true, the value wasn't being
encoded into the certificate.

With this fix, certificate chain verification should pass.

Fixes #2

Signed-off-by: David Brown <david.brown@linaro.org>