### PR TITLE
csr: switch CN and OU in CSR subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ We can now generate a sample CSR using the private key we just saved to
 
 ```bash
 $ openssl req -new -key USER.key -out USER.csr \
-  -subj "/O=localhost/CN=LinaroCA Device Cert - Signing/OU=$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  -subj "/O=localhost/CN=$(uuidgen | tr '[:upper:]' '[:lower:]')/OU=LinaroCA Device Cert - Signing"
 ```
 
 #### 4. Convert the CSR to JSON (`make_csr_json.go`)
@@ -356,7 +356,7 @@ Certificate:
         Validity
             Not Before: Dec  7 14:32:04 2021 GMT
             Not After : Dec  7 14:32:04 2022 GMT
-        Subject: O=localhost, OU=cb0dbc8a-2030-4799-a7af-183fddff04d7, CN=LinaroCA Device Cert - Signing
+        Subject: O=localhost, OU=LinaroCA Device Cert - Signing, CN=cb0dbc8a-2030-4799-a7af-183fddff04d7
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)

--- a/caserver/csr.go
+++ b/caserver/csr.go
@@ -46,8 +46,8 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	id := cert.Subject.OrganizationalUnit[0]
-	name := cert.Subject.CommonName
+	id := cert.Subject.CommonName
+	name := cert.Subject.OrganizationalUnit[0]
 	err = db.AddCert(id, name, ser, cert.SubjectKeyId, expiry, signedCert)
 	if err != nil {
 		fmt.Printf("Add cert err: %v\n", err)

--- a/make_csr_json.go
+++ b/make_csr_json.go
@@ -1,3 +1,4 @@
+//go:build never
 // +build never
 
 // This program reads a user CSR key (generated with openssl,
@@ -7,7 +8,7 @@
 //    openssl req -new -key USER.key -out USER.csr \
 //       -subj "/O=Orgname/CN=396c7a48-a1a6-4682-ba36-70d13f3b8902"
 //
-// The CN of the subject of the key should be the uinque identifier
+// The CN of the subject of the key should be the unique identifier
 // for the device being simulated.
 //
 // This program reads that file, and outputs a json csr request


### PR DESCRIPTION
Places the UUID in the CN field, and the certificate intent in the
OU field to keep Azure IoT Hub happy, since it expects the device ID
to be the same as the CN field, with no spaces or special characters.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>