### PR TITLE
Require mTLS for the CAserver.

### DIFF
--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -220,6 +220,12 @@ func kurPost(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"message": "kur POST called"}`))
 
 	// TODO: Validate current cert status and update/regen if necessary
+	// This should generate a new certificate for this client,
+	// based on the information from the existing certificate.
+	// This should _not_ invalidate or revoke the old certificate,
+	// as something such as an untimely power loss would cause the
+	// new key to be lost.  The old certificate is fine to use
+	// until it expires.
 }
 
 // Key revocation request

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -286,7 +286,7 @@ func Start(port int16) {
 		log.Fatal("Unable to open CADB.db database")
 	}
 
-	go registration()
+	// go registration()
 
 	// Create a certificate pool with the CA certificate.
 	certPool := x509.NewCertPool()

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -307,8 +307,13 @@ func Start(port int16) {
 		log.Fatal("Server certificate and key not found. See README.md.")
 	}
 
+	server := &http.Server{
+		Addr:    ":" + strconv.Itoa(int(port)),
+		Handler: r,
+	}
+
 	fmt.Println("Starting CA server on port https://localhost:" + strconv.Itoa(int(port)))
-	err = http.ListenAndServeTLS(":"+strconv.Itoa(int(port)), "certs/SERVER.crt", "certs/SERVER.key", r)
+	err = server.ListenAndServeTLS("certs/SERVER.crt", "certs/SERVER.key")
 	if err != nil {
 		log.Fatal("ListenAndServeTLS: ", err)
 	}

--- a/new-device.sh
+++ b/new-device.sh
@@ -38,6 +38,8 @@ go run make_csr_cbor.go -in $DEVPATH.csr -out $DEVPATH.cbor
 
 # Submit the CSR.
 wget --ca-certificate=certs/SERVER.crt \
+	--certificate=certs/BOOTSTRAP.crt \
+	--private-key=certs/BOOTSTRAP.key \
 	--post-file $DEVPATH.cbor \
 	--header "Content-Type: application/cbor" \
 	https://localhost:1443/api/v1/cr \
@@ -56,6 +58,6 @@ openssl verify -CAfile certs/CA.crt $DEVPATH.crt
 
 # Delete the files that aren't needed
 rm $DEVPATH.csr
-rm $DEVPATH.der
+rm $DEVPATH.cbor
 rm $DEVPATH.json
 rm $DEVPATH.rsp

--- a/setup-bootstrap.sh
+++ b/setup-bootstrap.sh
@@ -29,7 +29,7 @@ openssl ecparam -name prime256v1 -genkey -out certs/BOOTSTRAP.key
 # Generate the CSR
 openssl req -new -sha256 -key certs/BOOTSTRAP.key \
 	-out certs/BOOTSTRAP.csr \
-	-subj '/O=Linaro, LTD/CN=bootstrap-register-1'
+	-subj '/O=Linaro, LTD/CN=bootstrap-register-1/OU=LinaroCA Bootstrap Cert'
 
 # Sign it with our CA cert
 openssl x509 -req -sha256 \


### PR DESCRIPTION
Use the bootstrap cert/key to authenticate the client to the CAserver. The idea is to give this cert and key to each device within the factory, and this will prevent other devices from asking for signed certificates.