### PR TITLE
api: Update device/cert status endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ process (`/ap1/v1/cr`), and is a unique timestamp-based 64-bit integer (ex.
 `1635511354607407000`) that is added to the certificate before sending it back
 to the requesting device.
 
-It can be retrieved from a certificate via the serial number field, for
-example:
+It can be retrieved using the `/api/v1/ds/{uuid}` endpoint, or from a
+certificate file directly via the serial number field, for example:
 
 > The example belows assumes a specific device UUID, and `MBP2021.local` as
   the local hostname. These values will vary from one machine to another.
@@ -307,7 +307,7 @@ $ curl -v --cacert certs/SERVER.crt  \
           https://MBP2021.local:1443/api/v1/cs/1648935985023194000
 ```
 
-This endpoint will return one of three JSON response types:
+This endpoint will return one of three response types:
 
 - `{"status": "1"}` + HTTP response code **200**: Indicating that the serial
   number exists, and that the certificate is marked as **valid** in the CA
@@ -329,3 +329,20 @@ key or the current subject public key.
 ## `api/v1/krr` Key Revocation Request: **POST**
 
 Requests the revocation of an existing certificate registration.
+
+## `api/v1/ds/{uuid}` Device Status Request: **GET**
+
+Checks if any valid certificates are associated with the specified UUID. If
+any valid certificates are found, their serial number will be returned in
+the response payload.
+
+This endpoint accepts requests in cbor (`application/cbor`) or json
+(`application/json`), defaulting to JSON responses if no Content-Type is
+provided. The response Content-Type will match the request type used.
+
+```bash
+$ curl -v --cacert certs/SERVER.crt  \
+          --cert certs/BOOTSTRAP.crt \
+          --key certs/BOOTSTRAP.key  \
+          https://MBP2021.local:1443/api/v1/ds/56d38f73-3f6f-4a59-86bc-d315a1ccc634
+```

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/microbuilder/linaroca/cadb"
 	"github.com/microbuilder/linaroca/protocol"
@@ -239,37 +240,88 @@ func krrPost(w http.ResponseWriter, r *http.Request) {
 	// TODO: Mark certificate as revoked in the DB
 }
 
+// Test endpoint: https://localhost/api/v1/ds/{uuid}
+func dsGet(w http.ResponseWriter, r *http.Request) {
+	pathParams := mux.Vars(r)
+
+	// Check Content-Type request
+	use_cbor := false
+	switch r.Header.Get("Content-Type") {
+	case "application/cbor":
+		use_cbor = true
+	case "application/json":
+	case "":
+		// Default to JSON if not Content-Type provided (curl, etc.)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Bad request: Content-Type must be application/cbor or application/json"}`))
+		return
+	}
+
+	// Parse UUID from request
+	var err error
+	var devid uuid.UUID
+	if val, ok := pathParams["uuid"]; ok {
+		devid, err = uuid.Parse(val)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"message": "need a valid UUID"}`))
+			return
+		}
+	}
+
+	// Check UUID for valid certs
+	serials, err := db.CertsByUUID(devid)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Unable to query db for UUID: "}`))
+		log.Fatal("DB error: %s\n", err)
+		return
+	}
+
+	// CBOR response handler
+	if use_cbor {
+		// fmt.Printf("Got dev status request in CBOR for UUID: %s\n", devid)
+		w.Header().Set("Content-Type", "application/cbor")
+		w.WriteHeader(http.StatusOK)
+		enc := cbor.NewEncoder(w)
+		if serials == nil {
+			err = enc.Encode(&protocol.DevStatusResponse{
+				Status:  0,
+				Serials: nil,
+			})
+		} else {
+			err = enc.Encode(&protocol.DevStatusResponse{
+				Status:  1,
+				Serials: serials,
+			})
+		}
+		return
+	}
+
+	// Default JSON response handler
+	// fmt.Printf("Got dev status request in JSON for UUID: %s\n", devid)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	if serials == nil {
+		err = enc.Encode(&protocol.DevStatusResponse{
+			Status:  0,
+			Serials: nil,
+		})
+	} else {
+		err = enc.Encode(&protocol.DevStatusResponse{
+			Status:  1,
+			Serials: serials,
+		})
+	}
+}
+
 // REST API catch all handler
 func notFound(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte(`{"message": "endpoint not found"}`))
-}
-
-// Test endpoint: https://localhost/api/v1/status/123?format=cbor
-func statusGet(w http.ResponseWriter, r *http.Request) {
-	pathParams := mux.Vars(r)
-
-	w.Header().Set("Content-Type", "application/json")
-
-	deviceID := -1
-	var err error
-	if val, ok := pathParams["deviceID"]; ok {
-		deviceID, err = strconv.Atoi(val)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"message": "need a number"}`))
-			return
-		}
-	}
-
-	query := r.URL.Query()
-	format := query.Get("format")
-	if len(format) > 0 {
-		w.Write([]byte(fmt.Sprintf(`{"deviceID": %d, "format":, "%s"}`, deviceID, format)))
-	} else {
-		w.Write([]byte(fmt.Sprintf(`{"deviceID": %d}`, deviceID)))
-	}
 }
 
 // Root page handler
@@ -305,7 +357,7 @@ func Start(port int16) {
 	api.HandleFunc("/cs/{serial}", csGet).Methods(http.MethodGet)
 	api.HandleFunc("/kur", kurPost).Methods(http.MethodPost)
 	api.HandleFunc("/krr", krrPost).Methods(http.MethodPost)
-	api.HandleFunc("/status/{deviceID}", statusGet).Methods(http.MethodGet)
+	api.HandleFunc("/ds/{uuid}", dsGet).Methods(http.MethodGet)
 	api.HandleFunc("", notFound)
 
 	// Handle standard requests. Routes are tested in the order they are added,

--- a/protocol/status.go
+++ b/protocol/status.go
@@ -6,3 +6,7 @@ type DevStatusResponse struct {
 	Status  int       `cbor:"1,keyasint"`
 	Serials []big.Int `cbor:"2,keyasint"`
 }
+
+type CertStatusResponse struct {
+	Status int `cbor:"1,keyasint"`
+}

--- a/protocol/status.go
+++ b/protocol/status.go
@@ -1,0 +1,8 @@
+package protocol // github.com/microbuilder/linaroca/protocol
+
+import "math/big"
+
+type DevStatusResponse struct {
+	Status  int       `cbor:"1,keyasint"`
+	Serials []big.Int `cbor:"2,keyasint"`
+}


### PR DESCRIPTION
This PR adds a new `ds` endpoint to the REST API that accepts a UUID
and returns a list of valid certificate serial numbers associated with
that UUID.

It can be tested with some variation of:

JSON (default):

```bash
$ curl -v --cacert certs/SERVER.crt  \
          --cert certs/BOOTSTRAP.crt \
          --key certs/BOOTSTRAP.key  \
          https://MBP2021.local:1443/api/v1/ds/56d38f73-3f6f-4a59-86bc-d315a1ccc634
```

CBOR:

```bash
$ curl -v --cacert certs/SERVER.crt  \
          --cert certs/BOOTSTRAP.crt \
          --key certs/BOOTSTRAP.key  \
          -H 'Content-Type: application/cbor' \
          https://MBP2021.local:1443/api/v1/ds/56d38f73-3f6f-4a59-86bc-d315a1ccc634
```

It also extends the previously implemented `cs` endpoint to accept
CBOR requests, and make use of `protocol.CertStatusResponse` to
format the response payloads.