### PR TITLE
Add MQTT server information to the cert response

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ endpoint.
 #### Response
 
 Replies with a CBOR array containing `Status` and `Cert` fields, where `Cert`
-contains the BASE64-encoded certificate. 
+contains the BASE64-encoded certificate.  Hubname and Port indicate the hubname
+and port of the Azure MQTT broker service this certificate is for.  This is
+likely to change in the future.
 
 `Status` is an error code where `0` indicates success, and non-zero values
 should be treated as an error.
@@ -196,6 +198,8 @@ The types used in the CBOR response are as follows:
 {
    1 => int,   ; Status.
    2 => bstr,  ; Certificate
+   3 => tstr,  ; Hubname
+   4 => int,   ; Port
 }
 ```
 
@@ -241,6 +245,10 @@ contains the BASE64-encoded certificate.
 
 `Status` is an error code where `0` indicates success, and non-zero values
 should be treated as an error.
+
+The json response will also contain a string "Hubname" and an int "Port" which
+indicate the hubname and port to use with the Azure service.  This is likely to
+change in the future.
 
 ```json
 {

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/microbuilder/linaroca/cadb"
 	"github.com/microbuilder/linaroca/protocol"
+	"github.com/spf13/viper"
 )
 
 // The database itself.
@@ -75,21 +76,28 @@ func crPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	hubname := viper.GetString("server.hubname")
+	port := viper.GetInt("server.mqttport")
+
 	if use_cbor {
 		w.Header().Set("Content-Type", "application/cbor")
 		w.WriteHeader(http.StatusOK)
 		enc := cbor.NewEncoder(w)
 		err = enc.Encode(&protocol.CSRResponse{
-			Status: 0,
-			Cert:   cert,
+			Status:  0,
+			Cert:    cert,
+			Hubname: hubname,
+			Port:    port,
 		})
 	} else {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		enc := json.NewEncoder(w)
 		err = enc.Encode(&protocol.CSRResponse{
-			Status: 0,
-			Cert:   cert,
+			Status:  0,
+			Cert:    cert,
+			Hubname: hubname,
+			Port:    port,
 		})
 	}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -22,9 +22,11 @@ func init() {
 	// Configure the cloud service.
 	serverCmd.PersistentFlags().String("hubname", "hubname", "Azure Hub Name")
 	serverCmd.PersistentFlags().String("resourcegroup", "resourcegroup", "Azure Resource Group")
+	serverCmd.PersistentFlags().String("mqttport", "mqttport", "Azure MQTT Port")
 
 	viper.BindPFlag("server.hubname", serverCmd.PersistentFlags().Lookup("hubname"))
 	viper.BindPFlag("server.resourcegroup", serverCmd.PersistentFlags().Lookup("resourcegroup"))
 	viper.BindPFlag("server.port", serverCmd.PersistentFlags().Lookup("port"))
 	viper.BindPFlag("server.mport", serverCmd.PersistentFlags().Lookup("mport"))
+	viper.BindPFlag("server.mqttport", serverCmd.PersistentFlags().Lookup("mqttport"))
 }

--- a/protocol/csr.go
+++ b/protocol/csr.go
@@ -6,6 +6,8 @@ type CSRRequest struct {
 }
 
 type CSRResponse struct {
-	Status int    `cbor:"1,keyasint"`
-	Cert   []byte `cbor:"2,keyasint"`
+	Status  int    `cbor:"1,keyasint"`
+	Cert    []byte `cbor:"2,keyasint"`
+	Hubname string `cbor:"3,keyasint"`
+	Port    int    `cbor:"4,keyasint"`
 }


### PR DESCRIPTION
Under the `[server]` section in the `.linaroca.toml` file, handle
entries for 'hubname' and 'mqttport'.  These will both be handed off in
the information packet to the client so that the client doesn't need
hardcoded information about the particular service being used.
Currently, we are still assuming Azure as the provider.

Signed-off-by: David Brown <david.brown@linaro.org>