### PR TITLE
[WIP] Add support for PKCS#11 HSM interface for key storage

### DIFF
--- a/cadb/schema.go
+++ b/cadb/schema.go
@@ -11,10 +11,18 @@ var schema = []string{
 	`CREATE TABLE settings (key STRING PRIMARY KEY,
 		value STRING NOT NULL)`,
 
+	// owners holds information on vendors/OEMs who own devices managed
+	// by this server. Each owner will be associated with an intermediate
+	// signing certificate, which is used to sign device CSRs for that vendor.
+	`CREATE TABLE owners (id STRING PRIMARY KEY,
+		name STRING NOT NULL,
+		valid INTEGER NOT NULL)`,
+
 	// devices holds all devices known to the system.  The id is
 	// the identifier from the CSR.  `registered` indicates that
 	// the service considers this to be a valid device.
 	`CREATE TABLE devices (id STRING PRIMARY KEY,
+		owner STRING NOT NULL REFERENCES owners(id),
 		registered INTEGER NOT NULL)`,
 
 	// certs holds all of the certificates we've ever issued.
@@ -28,7 +36,7 @@ var schema = []string{
 		PRIMARY KEY (id, serial))`,
 }
 
-const schemaVersion = "20220215a"
+const schemaVersion = "20221206a"
 
 func (conn *Conn) checkSchema() error {
 	// Query the settings table for the schema version.

--- a/caserver/csr.go
+++ b/caserver/csr.go
@@ -41,7 +41,8 @@ func handleCSR(asn1Data []byte) ([]byte, error) {
 
 	id := cert.Subject.CommonName
 	name := cert.Subject.OrganizationalUnit[0]
-	err = db.AddCert(id, name, ser, cert.SubjectKeyId, expiry, signedCert)
+	owner := "d7:53:d0:ea:f9:65:8d:80" // TODO: Track proper owner UUID
+	err = db.AddCert(id, name, ser, cert.SubjectKeyId, expiry, signedCert, owner)
 	if err != nil {
 		fmt.Printf("Add cert err: %v\n", err)
 		return nil, err

--- a/cloud/api.go
+++ b/cloud/api.go
@@ -8,12 +8,14 @@ import (
 	"github.com/spf13/viper"
 )
 
-type CloudService interface {
+// A Service describes how to interact in a general way with the
+// supported cloud services.
+type Service interface {
 	Register(device string) error
 }
 
 // GetService retrieves a service with a given name.
-func GetService(name string) (CloudService, error) {
+func GetService(name string) (Service, error) {
 	if name == "azure-cli" {
 		return &azureService{}, nil
 	} else if name == "none" {

--- a/cloud/doc.go
+++ b/cloud/doc.go
@@ -1,5 +1,4 @@
 // Package cloud manages an abstract interaction with an external
 // cloud service.  The type of cloud service used will be determined
 // by configuration.
-
 package cloud // import "github.com/Linaro/lite_bootstrap_server/cloud"

--- a/cmd/hsm-info.go
+++ b/cmd/hsm-info.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Linaro/lite_bootstrap_server/hsm"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -39,21 +40,36 @@ var hsmInfoCmd = &cobra.Command{
 
 		// Generate test keys with:
 		//
+		// $ #ECUUID=$(uuidgen | tr -d -)
+		// $ #RSAUUID=$(uuidgen | tr -d -)
+		// $ ECUUID=90adf2460d194726ac2235071c5c148b
+		// $ RSAUUID=8ce44ddceced463bb6e191efcbb25edb
 		// $ pkcs11-tool --module /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so \
-		//   -l -p 1234 -k --id `uuidgen | tr -d -` --label "Test EC Key" \
+		//   -l -p 1234 -k --id $ECUUID --label "Test EC Key" \
 		//   --key-type EC:prime256v1
 		//
 		// $ pkcs11-tool --module /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so \
-		//   -l -p 1234 -k --id `uuidgen | tr -d -` --label "Test RSA Key" \
+		//   -l -p 1234 -k --id $RSAUUID --label "Test RSA Key" \
 		//   --key-type rsa:2048
+		//
+		// The keys can be deleted with:
+		//
+		// $ pkcs11-tool --module <...> \
+		//   -l -p 1234 -b --type privkey --label "Test EC Key"
+		//
+		// $ pkcs11-tool --module <...> \
+		//   -l -p 1234 -b --type pubkey --label "Test EC Key"
+		//
+		// etc for the RSA key
 
 		// Search for the Root CA Key
 		// uuid, _ := uuid.Parse("8ce44ddc-eced-463b-b6e1-91efcbb25edb") // RSA
-		// uuid, _ := uuid.Parse("90adf246-0d19-4726-ac22-35071c5c148b") // EC
-		// if err := hsm.FindObjectsByUUID(uuid, 10); err != nil {
-		// 	fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
-		// 	os.Exit(1)
-		// }
+		uuid, _ := uuid.Parse("90adf246-0d19-4726-ac22-35071c5c148b") // EC
+		if err := hsm.FindObjectsByUUID(uuid, 10); err != nil {
+			fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+			os.Exit(1)
+		}
+
 		if err := hsm.FindObjectsByLabel("Test EC Key", 10); err != nil {
 			fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
 			os.Exit(1)

--- a/cmd/hsm-info.go
+++ b/cmd/hsm-info.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/Linaro/lite_bootstrap_server/hsm"
+	"github.com/spf13/cobra"
+)
+
+var hsmInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "PKCS#11 Module Info",
+	Long:  `Display technical details of the PKCS#11 HSM interface being used.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// HSM Info
+		if err := hsm.DisplayHSMInfo(); err != nil {
+			if errors.Is(err, hsm.ErrQueryFailure) {
+				fmt.Println("Error trying to get module info from the PKCS#11 module.")
+				os.Exit(1)
+			}
+			// Catch all handler
+			fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+			os.Exit(1)
+		}
+
+		// Token/Slot Info
+		if err := hsm.DisplaySlotInfo(); err != nil {
+			if errors.Is(err, hsm.ErrQueryFailure) {
+				fmt.Println("Error trying to get slot 0 info from the PKCS#11 module.")
+				os.Exit(1)
+			}
+			// Catch all handler
+			fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+			os.Exit(1)
+		}
+
+		// Generate test keys with:
+		//
+		// $ pkcs11-tool --module /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so \
+		//   -l -p 1234 -k --id `uuidgen | tr -d -` --label "Test EC Key" \
+		//   --key-type EC:prime256v1
+		//
+		// $ pkcs11-tool --module /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so \
+		//   -l -p 1234 -k --id `uuidgen | tr -d -` --label "Test RSA Key" \
+		//   --key-type rsa:2048
+
+		// Search for the Root CA Key
+		// uuid, _ := uuid.Parse("8ce44ddc-eced-463b-b6e1-91efcbb25edb") // RSA
+		// uuid, _ := uuid.Parse("90adf246-0d19-4726-ac22-35071c5c148b") // EC
+		// if err := hsm.FindObjectsByUUID(uuid, 10); err != nil {
+		// 	fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+		// 	os.Exit(1)
+		// }
+		if err := hsm.FindObjectsByLabel("Test EC Key", 10); err != nil {
+			fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	hsmCmd.AddCommand(hsmInfoCmd)
+}

--- a/cmd/hsm-info.go
+++ b/cmd/hsm-info.go
@@ -77,6 +77,20 @@ var hsmInfoCmd = &cobra.Command{
 	},
 }
 
+var hsmCreateKeyCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a PKCS#11 Keypair",
+	Long:  "Create a new pkcs#11 keypair",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := hsm.CreateRootCAKey()
+		if err != nil {
+			fmt.Printf("pkcs#11 error: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
 	hsmCmd.AddCommand(hsmInfoCmd)
+	hsmCmd.AddCommand(hsmCreateKeyCmd)
 }

--- a/cmd/hsm.go
+++ b/cmd/hsm.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var hsmCmd = &cobra.Command{
+	Use:   "hsm",
+	Short: "PKCS#11 hardware security module key management",
+	Long:  `Key management using a PKCS#11 compliant HSM module.`,
+}
+
+func init() {
+	rootCmd.AddCommand(hsmCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
 
-	"github.com/Linaro/lite_bootstrap_server/hsm"
+	// "github.com/Linaro/lite_bootstrap_server/hsm"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -30,8 +29,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig, initHSM)
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default \"$HOME/.liteboot.yaml\")")
 	rootCmd.PersistentFlags().String("hsm-module", "", "PKCS#11 module path and filename")
 	rootCmd.PersistentFlags().String("hsm-pin", "1234", "PKCS#11 module pin")
@@ -64,70 +61,5 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
-	}
-}
-
-// InitHSM initialises the hardware secure module using the PKCS#11 interface
-func initHSM() {
-	pkcs11Module := viper.GetString("hsm.module")
-	pkcs11Pin := viper.GetString("hsm.pin")
-
-	// Show a useful warning if no HSM module specified
-	if pkcs11Module == "" {
-		fmt.Printf("No PKCS#11 module detected.\n\n")
-		fmt.Printf("This server relies on a hardware secure module (HSM) being present for\n")
-		fmt.Printf("secure key storage, communicating over a standard PKCS#11 interface.\n\n")
-		fmt.Printf("If using the default setup, make sure SoftHSM is installed and configured\n")
-		fmt.Printf("on your system, and specify the module's path/filename via '--hsm-module',\n")
-		fmt.Printf("or via 'module' in the '[hsm]' section of the config file.")
-		os.Exit(1)
-	}
-
-	// Show a useful warning if no HSM pin specified
-	if pkcs11Pin == "" {
-		fmt.Printf("No PKCS#11 pin specified.\n\n")
-		fmt.Printf("Access to the HSM requires a pin to be specified. Please specify the pin\n")
-		fmt.Printf("via '--hsm-pin' or via 'pin' in the '[hsm]' section of the config file.")
-		os.Exit(1)
-	}
-
-	// Display the HSM module being used
-	fmt.Printf("Using PKCS#11 module: %s\n", pkcs11Module)
-
-	// Do some exhaustive error checking to make sure the HSM is setup properly
-	err := hsm.TestConnection()
-	if err != nil {
-		// Incorrect path/filename or init failure
-		if errors.Is(err, hsm.ErrInvalidFilename) || errors.Is(err, hsm.ErrInitFailure) {
-			fmt.Printf("Invalid PKCS#11 path/filename: %s\n", pkcs11Module)
-			fmt.Println("Please set a valid PKCS#11 module path/filename via '--hsm-module'")
-			os.Exit(1)
-		}
-
-		// No slot(s) defined
-		if errors.Is(err, hsm.ErrMissingSlot) {
-			fmt.Println("Unable to get the slot list for the PKCS#11 module.")
-			fmt.Println("Create an empty token in slot 0, setting an appropriate pin via:")
-			fmt.Println("")
-			fmt.Println("$ softhsm2-util --init-token --slot 0 --label \"LITEBoot\" --pin 1234")
-			os.Exit(1)
-		}
-
-		// Failed opening slot 0
-		if errors.Is(err, hsm.ErrSessionFailure) {
-			fmt.Println("Unable to open a session for the PKCS#11 module in slot 0.")
-			os.Exit(1)
-		}
-
-		// Invalid PIN code
-		if errors.Is(err, hsm.ErrLoginFailure) {
-			fmt.Println("Login failed for PKCS#11 module in slot 0.")
-			fmt.Println("Please set a valid PKCS#11 pin via '--hsm-pin'")
-			os.Exit(1)
-		}
-
-		// Catch all handler
-		fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
-		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/Linaro/lite_bootstrap_server/hsm"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -13,14 +15,10 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "liteboot",
 	Short: "Linaro bootstrap and certificate authority server",
 	Long:  `A proof-of-concept certificate authority (CA) and management tool.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -32,17 +30,14 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig, initHSM)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default \"$HOME/.liteboot.yaml\")")
+	rootCmd.PersistentFlags().String("hsm-module", "", "PKCS#11 module path and filename")
+	rootCmd.PersistentFlags().String("hsm-pin", "1234", "PKCS#11 module pin")
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.liteboot.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	viper.BindPFlag("hsm.module", rootCmd.PersistentFlags().Lookup("hsm-module"))
+	viper.BindPFlag("hsm.pin", rootCmd.PersistentFlags().Lookup("hsm-pin"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -69,5 +64,70 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}
+
+// InitHSM initialises the hardware secure module using the PKCS#11 interface
+func initHSM() {
+	pkcs11Module := viper.GetString("hsm.module")
+	pkcs11Pin := viper.GetString("hsm.pin")
+
+	// Show a useful warning if no HSM module specified
+	if pkcs11Module == "" {
+		fmt.Printf("No PKCS#11 module detected.\n\n")
+		fmt.Printf("This server relies on a hardware secure module (HSM) being present for\n")
+		fmt.Printf("secure key storage, communicating over a standard PKCS#11 interface.\n\n")
+		fmt.Printf("If using the default setup, make sure SoftHSM is installed and configured\n")
+		fmt.Printf("on your system, and specify the module's path/filename via '--hsm-module',\n")
+		fmt.Printf("or via 'module' in the '[hsm]' section of the config file.")
+		os.Exit(1)
+	}
+
+	// Show a useful warning if no HSM pin specified
+	if pkcs11Pin == "" {
+		fmt.Printf("No PKCS#11 pin specified.\n\n")
+		fmt.Printf("Access to the HSM requires a pin to be specified. Please specify the pin\n")
+		fmt.Printf("via '--hsm-pin' or via 'pin' in the '[hsm]' section of the config file.")
+		os.Exit(1)
+	}
+
+	// Display the HSM module being used
+	fmt.Printf("Using PKCS#11 module: %s\n", pkcs11Module)
+
+	// Do some exhaustive error checking to make sure the HSM is setup properly
+	err := hsm.TestConnection()
+	if err != nil {
+		// Incorrect path/filename or init failure
+		if errors.Is(err, hsm.ErrInvalidFilename) || errors.Is(err, hsm.ErrInitFailure) {
+			fmt.Printf("Invalid PKCS#11 path/filename: %s\n", pkcs11Module)
+			fmt.Println("Please set a valid PKCS#11 module path/filename via '--hsm-module'")
+			os.Exit(1)
+		}
+
+		// No slot(s) defined
+		if errors.Is(err, hsm.ErrMissingSlot) {
+			fmt.Println("Unable to get the slot list for the PKCS#11 module.")
+			fmt.Println("Create an empty token in slot 0, setting an appropriate pin via:")
+			fmt.Println("")
+			fmt.Println("$ softhsm2-util --init-token --slot 0 --label \"LITEBoot\" --pin 1234")
+			os.Exit(1)
+		}
+
+		// Failed opening slot 0
+		if errors.Is(err, hsm.ErrSessionFailure) {
+			fmt.Println("Unable to open a session for the PKCS#11 module in slot 0.")
+			os.Exit(1)
+		}
+
+		// Invalid PIN code
+		if errors.Is(err, hsm.ErrLoginFailure) {
+			fmt.Println("Login failed for PKCS#11 module in slot 0.")
+			fmt.Println("Please set a valid PKCS#11 pin via '--hsm-pin'")
+			os.Exit(1)
+		}
+
+		// Catch all handler
+		fmt.Printf("Unhandled PKCS#11 error: %s\n", err)
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12
+	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/hsm/hsm.go
+++ b/hsm/hsm.go
@@ -1,0 +1,243 @@
+package hsm
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/miekg/pkcs11"
+	"github.com/spf13/viper"
+)
+
+var ErrInvalidParam = errors.New("invalid input parameter")
+var ErrInvalidFilename = errors.New("invalid pkcs#11 module path/filename")
+var ErrInitFailure = errors.New("pkcs#11 module init failure")
+var ErrMissingSlot = errors.New("no slot defined")
+var ErrSessionFailure = errors.New("unable to open session with slot 0")
+var ErrLoginFailure = errors.New("unable to login to slot 0 with the specific pin")
+var ErrQueryFailure = errors.New("unable to execute the requested PKCS#11 api call")
+
+// Protoype for pkcs#11 functions to run after connection validation in exec
+type execFn func(p *pkcs11.Ctx, s pkcs11.SessionHandle) error
+
+// exec performs basic error checking for PKCS#11 queries
+func exec(fn execFn) error {
+	module := viper.GetString("hsm.module")
+	pin := viper.GetString("hsm.pin")
+
+	if module == "" || pin == "" {
+		return ErrInvalidParam
+	}
+
+	// Make sure the specified PKCS#11 shared module actually exists
+	_, err := os.Stat(module)
+	if err != nil {
+		return ErrInvalidFilename
+	}
+
+	// Try to initialise the shared module
+	p := pkcs11.New(module)
+	if err = p.Initialize(); err != nil {
+		return ErrInitFailure
+	}
+
+	defer p.Destroy()
+	defer p.Finalize()
+
+	// Make sure there is a slot defined
+	// ToDo: Check for a specific label (LITEBoot)!
+	slots, err := p.GetSlotList(true)
+	if err != nil {
+		return ErrMissingSlot
+	}
+
+	// Try to open a new session using slot 0
+	session, err := p.OpenSession(slots[0], pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	if err != nil {
+		return ErrSessionFailure
+	}
+	defer p.CloseSession(session)
+
+	// Attempt to login to slot 0 using the user context pin
+	if err = p.Login(session, pkcs11.CKU_USER, pin); err != nil {
+		return ErrLoginFailure
+	}
+	defer p.Logout(session)
+
+	// PKCS#11 module seems to be OK, run the supplied function if present
+	if fn != nil {
+		err = fn(p, session)
+	}
+
+	return err
+}
+
+func TestConnection() error {
+	// No exec function required since we just want to connect and exit
+	return exec(nil)
+}
+
+func DisplayHSMInfo() error {
+	var f = func(p *pkcs11.Ctx, s pkcs11.SessionHandle) error {
+		info, err := p.GetInfo()
+		if err != nil {
+			return ErrQueryFailure
+		}
+
+		fmt.Printf("HSM:\n")
+		fmt.Printf("  Name: %s\n", info.ManufacturerID)
+		fmt.Printf("  Cryptoki: %v.%v\n", info.CryptokiVersion.Major, info.CryptokiVersion.Minor)
+		fmt.Printf("  Library: %v.%v\n", info.LibraryVersion.Major, info.LibraryVersion.Minor)
+
+		return nil
+	}
+
+	return exec(f)
+}
+
+func DisplaySlotInfo() error {
+	var f = func(p *pkcs11.Ctx, s pkcs11.SessionHandle) error {
+		sinfo, err := p.GetSessionInfo(s)
+		if err != nil {
+			return ErrQueryFailure
+		}
+
+		fmt.Printf("Slot 0:\n")
+		fmt.Printf("  ID: 0x%x\n", sinfo.SlotID)
+
+		tinfo, err := p.GetTokenInfo(sinfo.SlotID)
+		if err != nil {
+			return ErrQueryFailure
+		}
+
+		fmt.Printf("  Token label: %s\n", tinfo.Label)
+		fmt.Printf("  Serial: %s\n", tinfo.SerialNumber)
+
+		return nil
+	}
+
+	return exec(f)
+}
+
+func displayObject(p *pkcs11.Ctx, s pkcs11.SessionHandle, o pkcs11.ObjectHandle) error {
+	attr, err := p.GetAttributeValue(s, o, []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, nil), // CKK_RSA, CKK_EC, etc.
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, nil),    // CKO_PUBLIC_KEY, CKO_PRIVATE_KEY, etc.
+	})
+	if err != nil {
+		return ErrQueryFailure
+	}
+
+	// Render the matching attributes
+	for _, a := range attr {
+		fmt.Printf("    ")
+		switch a.Type {
+		case pkcs11.CKA_KEY_TYPE:
+			fmt.Printf("Key Type: ")
+			switch a.Value[0] {
+			case pkcs11.CKK_RSA:
+				fmt.Printf("RSA\n")
+			case pkcs11.CKK_EC:
+				fmt.Printf("EC\n")
+			default:
+				fmt.Printf("%d\n", a.Value[0])
+			}
+		case pkcs11.CKA_LABEL:
+			fmt.Printf("Label: %s\n", a.Value)
+		case pkcs11.CKA_CLASS:
+			fmt.Printf("Class: ")
+			switch a.Value[0] {
+			case pkcs11.CKO_PUBLIC_KEY:
+				fmt.Printf("Public Key\n")
+			case pkcs11.CKO_PRIVATE_KEY:
+				fmt.Printf("Private Key\n")
+			default:
+				fmt.Printf("%d\n", a.Value[0])
+			}
+		case pkcs11.CKA_ID:
+			fmt.Printf("ID: %x\n", a.Value)
+		default:
+			fmt.Printf("0x%04X: %s (len %d)\n", a.Type, hex.EncodeToString(a.Value), len(a.Value))
+		}
+	}
+
+	return nil
+}
+
+func FindObjectsByLabel(label string, max int) error {
+	var f = func(p *pkcs11.Ctx, s pkcs11.SessionHandle) error {
+		// Set the search parameters
+		t := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+		}
+
+		if err := p.FindObjectsInit(s, t); err != nil {
+			return ErrQueryFailure
+		}
+
+		// Get the first object that matches t
+		o, _, err := p.FindObjects(s, max)
+		if err != nil {
+			return ErrQueryFailure
+		}
+
+		// Clean up
+		if err = p.FindObjectsFinal(s); err != nil {
+			return ErrQueryFailure
+		}
+
+		// Display matching object
+		fmt.Printf("Found %d objects with label \"%s\"\n", len(o), label)
+		for i, obj := range o {
+			fmt.Printf("  Object %d:\n", i)
+			if err := displayObject(p, s, obj); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return exec(f)
+}
+
+func FindObjectsByUUID(u uuid.UUID, max int) error {
+	var f = func(p *pkcs11.Ctx, s pkcs11.SessionHandle) error {
+		// Set the search parameters
+		t := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, []byte(u[0:])),
+		}
+
+		if err := p.FindObjectsInit(s, t); err != nil {
+			return ErrQueryFailure
+		}
+
+		// Get the first object that matches t
+		o, _, err := p.FindObjects(s, max)
+		if err != nil {
+			return ErrQueryFailure
+		}
+
+		// Clean up
+		if err = p.FindObjectsFinal(s); err != nil {
+			return ErrQueryFailure
+		}
+
+		// Display matching object
+		fmt.Printf("Found %d objects with UUID \"%s\"\n", len(o), u.String())
+		for i, obj := range o {
+			fmt.Printf("  Object %d:\n", i)
+			if err := displayObject(p, s, obj); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return exec(f)
+}

--- a/mtlsserver/mtlsserver.go
+++ b/mtlsserver/mtlsserver.go
@@ -49,7 +49,7 @@ func handleConnection(c net.Conn) {
 	c.Close()
 }
 
-// Starts a TCP server with mTLS authentication
+// StartTCP starts a TCP server with mTLS authentication
 func StartTCP(hostname string, port int16) {
 	// Create a certificate pool with the CA certificate
 	certPool := x509.NewCertPool()

--- a/protocol/cc.go
+++ b/protocol/cc.go
@@ -1,5 +1,6 @@
 package protocol // github.com/Linaro/lite_bootstrap_server/protocol
 
+// A CCResponse is the packet response to get a certificate.
 type CCResponse struct {
 	Status int    `cbor:"1,keyasint"`
 	Cert   string `cbor:"2,keyasint"`

--- a/protocol/ccs.go
+++ b/protocol/ccs.go
@@ -1,5 +1,6 @@
 package protocol // github.com/Linaro/lite_bootstrap_server/protocol
 
+// A CCSResponse is the response to the ccs request.
 type CCSResponse struct {
 	Hubname string `cbor:"1,keyasint"`
 	Port    int    `cbor:"2,keyasint"`

--- a/protocol/csr.go
+++ b/protocol/csr.go
@@ -1,10 +1,13 @@
 package protocol // github.com/Linaro/lite_bootstrap_server/protocol
 
+// A CSRRequest is the incoming request for a signature.
 type CSRRequest struct {
 	_   struct{} `cbor:",toarray"`
 	CSR []byte
 }
 
+// A CSRResponse is the response to the signature, containing the
+// signature itself.
 type CSRResponse struct {
 	Status int    `cbor:"1,keyasint"`
 	Cert   []byte `cbor:"2,keyasint"`

--- a/protocol/status.go
+++ b/protocol/status.go
@@ -2,11 +2,14 @@ package protocol // github.com/Linaro/lite_bootstrap_server/protocol
 
 import "math/big"
 
+// The DevStatusResponse returns information on the device.
 type DevStatusResponse struct {
 	Status  int       `cbor:"1,keyasint"`
 	Serials []big.Int `cbor:"2,keyasint"`
 }
 
+// The CertStatusResponse returns status information on the given
+// certificate.
 type CertStatusResponse struct {
 	Status int `cbor:"1,keyasint"`
 }

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -68,10 +68,10 @@ func NewSigningCert() (*SigningCert, error) {
 	// Determine the KeyID based on the sha1 of the marshalled
 	// public key.
 	pubBytes := elliptic.Marshal(privKey.Curve, privKey.X, privKey.Y)
-	keyId := sha1.Sum(pubBytes)
+	keyID := sha1.Sum(pubBytes)
 
-	ca.SubjectKeyId = keyId[:]
-	ca.AuthorityKeyId = keyId[:]
+	ca.SubjectKeyId = keyID[:]
+	ca.AuthorityKeyId = keyID[:]
 
 	// Self sign this key.
 	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, &privKey.PublicKey, privKey)
@@ -85,6 +85,8 @@ func NewSigningCert() (*SigningCert, error) {
 	}, nil
 }
 
+// SignTemplate creates a certificate based off of the given signing
+// template.
 func (s *SigningCert) SignTemplate(template *x509.Certificate, pub interface{}) ([]byte, error) {
 	ecPub, ok := pub.(*ecdsa.PublicKey)
 	if !ok {
@@ -96,9 +98,9 @@ func (s *SigningCert) SignTemplate(template *x509.Certificate, pub interface{}) 
 	// x509 library, provided we're using a recent enough version
 	// of Go.
 	pubBytes := elliptic.Marshal(ecPub.Curve, ecPub.X, ecPub.Y)
-	keyId := sha1.Sum(pubBytes)
+	keyID := sha1.Sum(pubBytes)
 
-	template.SubjectKeyId = keyId[:]
+	template.SubjectKeyId = keyID[:]
 
 	return x509.CreateCertificate(rand.Reader, template, s.Cert,
 		pub, s.PrivateKey)


### PR DESCRIPTION
Initial attempt at enabling HSM support for key storage using PKCS#11.

Tested using [SoftHSM](https://www.opendnssec.org/softhsm/), which can be built from source or installed with a package manager (ex. `brew install softhsm`). This also requires OpenSSL as a backend by default.

A new test token must be created before running this sample, via some variation of the following:

```bash
$ softhsm2-util --init-token --slot 0 --label "Test Token" --pin 1234
```

You can then pass in the shared library for the HSM module, adding a `--pin` parameter if you use a pin other than `1234`, via:

```bash
$ go build -o liteboot
```
```bash
$ ./liteboot hsm info \
  --hsm-module="/opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so"
Using config file: <path>/lite_bootstrap_server/.liteboot.toml
Using PKCS#11 module: /opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so
Manufacturer: SoftHSM
Cryptoki Version: 2.40
Library Version: 2.6
```

Alternatively, you can specify the pin and module flags in your `.liteboot.toml` file as follows:

```toml
[hsm]
module = "/opt/homebrew/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so"
# pin = "1234"
```
